### PR TITLE
0.50.0

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -3,6 +3,6 @@ cdt_name:
 channel_sources:
 - conda-forge
 channel_targets:
-- conda-forge openff-qcsubmit_rc
+- conda-forge
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64

--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -3,6 +3,6 @@ cdt_name:
 channel_sources:
 - conda-forge
 channel_targets:
-- conda-forge
+- conda-forge main
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,2 +1,0 @@
-channel_targets:
-- conda-forge

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,0 +1,2 @@
+channel_targets:
+- conda-forge

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,2 +1,0 @@
-channel_targets:
-- conda-forge openff-qcsubmit_rc

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "openff-qcsubmit" %}
-{% set version = "0.50.0rc1" %}
+{% set version = "0.50.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/openforcefield/openff-qcsubmit/archive/{{ version }}.tar.gz
-  sha256: 41e94435a04ddaafda1a728760f54b614c9b7b4c3d84f5f07cfb49f7cb14ed7b
+  sha256: f642eccb803f5db07c9d87c998a7378a125abc7c27d594ed1a3d79c243fe4e0b
 
 build:
   noarch: python


### PR DESCRIPTION
I tested locally. Except for the fact that many deps are optional, the following command got all-green tests for me using the 0.50.0rc1 package:

```
mamba create -n temp -c conda-forge/label/openff-qcsubmit_rc -c conda-forge/label/libint_dev -c openeye openff-qcsubmit openeye-toolkits psi4 pytest qcarchivetesting openmmforcefields postgresql h5py openff-fragmenter
pytest  --basetemp="/Users/jeffreywagner/temp"  -vvvvv
```

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
